### PR TITLE
updated to timestamp feature importance runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@
 Log(ML) is a framework that helps automate many steps in machine learning projects and let you quickly generate baseline results.
 
 # See [Documentation](https://astrazeneca-ngs.github.io/LogMl/)
+
+NOTE: this branch is a temp hack to timestamp feature selection output `csv` files.

--- a/src/logml/feature_importance/data_feature_importance.py
+++ b/src/logml/feature_importance/data_feature_importance.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import datetime
 import matplotlib.pyplot as plt
 import numpy as np
 import subprocess
@@ -559,13 +560,17 @@ class DataFeatureImportance(MlFiles):
         if self.results.is_empty():
             self._debug(f"Feature importance {self.tag}: Enpty resutls, nothing to show or save")
             return
+
+        # Get current timestamp
+        dt = datetime.datetime.utcnow().isoformat(sep='.').replace(':', '').replace('-', '')
+
         # Show and save main results table
         self.results.print(f"Feature importance {self.tag}")
-        fimp_csv = self.datasets.get_file_name(f'feature_importance_{self.tag}', ext=f"csv")
+        fimp_csv = self.datasets.get_file_name(f'feature_importance_{self.tag}_{dt}', ext=f"csv")
         self._info(f"Feature importance {self.tag}: Saving results to '{fimp_csv}'")
         self._save_csv(fimp_csv, f"Feature importance {self.tag}", self.results.df, save_index=True)
         # Show and save weights table
-        fimp_weights_csv = self.datasets.get_file_name(f'feature_importance_{self.tag}_weights', ext=f"csv")
+        fimp_weights_csv = self.datasets.get_file_name(f'feature_importance_{self.tag}_{dt}_weights', ext=f"csv")
         self._info(f"Feature importance {self.tag}: Saving weights to {fimp_weights_csv}")
         weights = self.results.get_weights_table()
         if loss_ori:


### PR DESCRIPTION
one may want to try different feature selection methods or hyperparameters; current implementation does not uniquely label (i.e. timestamp) the outputted feature importance `csv` dataframe.