### PR TITLE
fix scatter_total and scatter_num init

### DIFF
--- a/src/logml/core/config.py
+++ b/src/logml/core/config.py
@@ -57,7 +57,7 @@ class Config(MlFiles):
         self.is_debug = False
         self.is_verbose = False
         # self.exit_on_fatal_error = True
-        self.scatter_total, self.scatter_num = None, None
+        self.scatter_total, self.scatter_num = 0, 0
         if log_level:
             self.set_log_level(log_level)
 


### PR DESCRIPTION
Small fix.

The problem is when you run the LogMI thru the jupython notebook
`>> jupyter nbconvert --execute $HOME/logml/linear3c.ipynb --to html`
you recive the ERRROR:
`TypeError: '<=' not supported between instances of 'NoneType' and 'int' `
Thats because `self.scatter_total` and `self.scatter_num` initialised as None instead of initialising as an integer and program is comes out  [before](https://github.com/AstraZeneca-NGS/LogMl/blob/master/src/logml/core/config.py#L116) resolution of these variables

But if you run LogMI thru the cli command 
`>>$HOME/logml/scripts/run_linear3c.sh`
you will not faced with this error because during parsing CLI command `self.scatter_total` and `self.scatter_num` replaced to integer on [line](https://github.com/AstraZeneca-NGS/LogMl/blob/master/src/logml/core/config.py#L140)